### PR TITLE
added .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 package-lock.json
+.env
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
May be essential to getting Heroku build to work again. I'm suspicious about all this stuff with PROCESS.ENV.JSON_WEB_TOKEN_SECRET in general. Idk what Dan was thinking, I haven't seen anything like that in any other references or documentation I found.